### PR TITLE
Make cure escript start imminently when possible

### DIFF
--- a/lib/cure/compiler/artifacts.ex
+++ b/lib/cure/compiler/artifacts.ex
@@ -826,7 +826,7 @@ defmodule Cure.Compiler.Artifacts do
          expected_stat when is_map(expected_stat) <- Map.get(expected, :stat),
          {:ok, stat} <- File.stat(absolute, time: :posix),
          actual_stat <- stat_signature(stat),
-         true <- actual_stat == expected_stat,
+         true <- stat_matches?(expected_stat, actual_stat),
          true <- timestamp_safe?(actual_stat, validated_at) do
       increment_hash_stat(:reused)
       {:ok, expected}
@@ -835,9 +835,12 @@ defmodule Cure.Compiler.Artifacts do
     end
   end
 
-  defp timestamp_safe?(%{mtime: mtime, ctime: ctime}, validated_at)
+  defp stat_matches?(%{size: s, mtime: m}, %{size: s, mtime: m}), do: true
+  defp stat_matches?(_expected, _actual), do: false
+
+  defp timestamp_safe?(%{mtime: mtime}, validated_at)
        when is_integer(validated_at),
-       do: max(mtime, ctime) < validated_at
+       do: mtime < validated_at
 
   defp timestamp_safe?(_stat, _validated_at), do: false
 
@@ -858,7 +861,7 @@ defmodule Cure.Compiler.Artifacts do
     stat = path |> File.stat!(time: :posix) |> stat_signature()
     verification = Keyword.get(opts, :verification, :cached)
 
-    if verification == :cached and is_map(expected) and Map.get(expected, :stat) == stat and
+    if verification == :cached and is_map(expected) and stat_matches?(Map.get(expected, :stat), stat) and
          timestamp_safe?(stat, validated_at) do
       increment_hash_stat(:reused)
       expected

--- a/lib/cure/compiler/parser.ex
+++ b/lib/cure/compiler/parser.ex
@@ -37,7 +37,7 @@ defmodule Cure.Compiler.Parser do
   """
 
   alias Cure.Compiler.{MacroFamily, MacroRaw, Token}
-  alias Cure.Compiler.Parser.{BuiltinFixity, FixityTable, FixityScan, FixityResolver, Precedence}
+  alias Cure.Compiler.Parser.{BuiltinFixity, BuiltinMacros, FixityTable, FixityScan, FixityResolver, Precedence}
   alias Cure.Compiler.Parser.Range
   alias Cure.Diagnostic.{ProvenanceFrame, Span}
   alias Cure.MetaAST.Metadata
@@ -339,63 +339,51 @@ defmodule Cure.Compiler.Parser do
     exprs
   end
 
+  # The built-in `:syntax`/`:computed` macro grammar and suffix-keyed `literal`
+  # rule set, harvested from every bundled stdlib (+ embedded Regex package)
+  # source. Baked at ELIXIR COMPILE TIME by `BuiltinMacros` (mirroring
+  # `BuiltinFixity`'s built-in operator table) rather than lazily parsed on
+  # first use and memoized in `:persistent_term`: harvesting the grammar parses
+  # the whole stdlib source tree three times over (a harvest pass, a
+  # transitively-seeded reparse, and a literal-rule pass), which cost several
+  # seconds. That cost is invisible within one long-lived process (a `cure
+  # repl` session), but a fresh `cure` escript invocation starts a brand new
+  # VM with an empty `persistent_term` table, so `cure check`, the first line
+  # typed into a new `cure repl`, `cure run`, etc. paid the full harvest again
+  # on every single invocation — the "first call is slow, every other call is
+  # fast" symptom this bake removes. `Application.get_env(:cure,
+  # :stdlib_macro_rules)` remains as a legacy override escape hatch (unused
+  # anywhere in this codebase today); it carries no literal-rule channel,
+  # matching its historical behaviour.
   defp prelude_macros do
-    case {Process.get(:cure_loading_prelude), :persistent_term.get({__MODULE__, :prelude_macros}, :missing)} do
-      {true, _} -> %{}
-      {_, rules} when is_map(rules) -> rules
-      _ -> load_prelude_macros()
+    case Application.get_env(:cure, :stdlib_macro_rules) do
+      rules when is_map(rules) -> rules
+      _ -> BuiltinMacros.syntax_rules()
     end
   end
 
-  defp load_prelude_macros do
-    Process.put(:cure_loading_prelude, true)
-
-    {rules, literal_rules} =
-      case Application.get_env(:cure, :stdlib_macro_rules) do
-        rules when is_map(rules) ->
-          # Env-supplied grammar sets carry only keyword `:syntax` rules; there
-          # is no literal-rule channel for this legacy escape hatch.
-          {rules, %{}}
-
-        _ ->
-          stdlib_macro_paths =
-            (Path.wildcard(Path.expand("../../std/*.cure", __DIR__)) ++
-               Path.wildcard(Path.expand("../../std_deps/regex/*.cure", __DIR__)))
-            |> Enum.sort()
-
-          # First harvest every standard-library macro without any builtin
-          # rules. A second parse uses that complete grammar set so one
-          # standard-library macro can transparently invoke another (for
-          # example, standard-library starters invoking another syntax macro).
-          harvested = collect_stdlib_macro_rules(stdlib_macro_paths, %{})
-          syntax = collect_stdlib_macro_rules(stdlib_macro_paths, %{}, harvested)
-          literal = collect_stdlib_literal_rules(stdlib_macro_paths, harvested)
-          {syntax, literal}
-      end
-
-    :persistent_term.put({__MODULE__, :prelude_macros}, rules)
-    :persistent_term.put({__MODULE__, :prelude_literal_macros}, literal_rules)
-    Process.delete(:cure_loading_prelude)
-    rules
-  end
-
-  # Suffix-keyed `literal` rules gathered from every standard-library module, so
-  # a suffix such as `ms` expands in any file the way keyword `:syntax` macros
-  # are globally active. Populated as a side effect of `load_prelude_macros/0`
-  # (both persistent-term caches are written together); while the prelude is
-  # itself loading, no prelude literal rules are active (self-reference guard).
   defp prelude_literal_macros do
-    case {Process.get(:cure_loading_prelude), :persistent_term.get({__MODULE__, :prelude_literal_macros}, :missing)} do
-      {true, _} ->
-        %{}
-
-      {_, rules} when is_map(rules) ->
-        rules
-
-      _ ->
-        load_prelude_macros()
-        :persistent_term.get({__MODULE__, :prelude_literal_macros}, %{})
+    case Application.get_env(:cure, :stdlib_macro_rules) do
+      rules when is_map(rules) -> %{}
+      _ -> BuiltinMacros.literal_rules()
     end
+  end
+
+  @doc false
+  # Table-independent harvest of the stdlib's own macro grammar: parse every
+  # `path` with no active macros to collect the raw `:macro_def` rules
+  # (`harvested`), then reparse with that complete grammar seeded so one
+  # stdlib macro can transparently invoke another (e.g. a starter macro using
+  # another syntax macro), plus the suffix-keyed `literal` rules. Exposed so
+  # `BuiltinMacros` can bake the result into a compile-time constant; ordinary
+  # parsing never calls this directly (each `path` parses with
+  # `prelude_macros: false`, so no re-entrant harvest occurs).
+  @spec compute_prelude_macro_rules([Path.t()]) :: {map(), map()}
+  def compute_prelude_macro_rules(paths) do
+    harvested = collect_stdlib_macro_rules(paths, %{})
+    syntax = collect_stdlib_macro_rules(paths, %{}, harvested)
+    literal = collect_stdlib_literal_rules(paths, harvested)
+    {syntax, literal}
   end
 
   defp collect_stdlib_literal_rules(paths, builtin_macros) do

--- a/lib/cure/compiler/parser/builtin_macros.ex
+++ b/lib/cure/compiler/parser/builtin_macros.ex
@@ -1,0 +1,86 @@
+defmodule Cure.Compiler.Parser.BuiltinMacros do
+  @moduledoc """
+  The built-in `:syntax`/`:computed` macro grammar and suffix-keyed `literal`
+  rule set, harvested from every bundled stdlib (+ embedded Regex package)
+  source and baked at Elixir COMPILE TIME.
+
+  ## Why compile-time bake
+
+  `Cure.Compiler.Parser.parse/2` seeds every parse with the stdlib's own macro
+  grammar (`macro ... syntax ...` / `... computed ...` definitions declared in
+  `lib/std/*.cure` and the embedded `lib/std_deps/regex/*.cure`), so a `use
+  Std.Iter` file can use stdlib-provided syntax without the caller doing
+  anything. Computing that grammar means parsing the WHOLE stdlib source tree
+  three times over: a harvest pass with no active macros, a second reparse
+  with that complete grammar seeded (so one stdlib macro can transparently
+  invoke another), and a third pass for the suffix-keyed `literal` rules.
+
+  Doing that lazily, memoized only in `:persistent_term`
+  (`Cure.Compiler.Parser`'s previous implementation), is invisible within one
+  long-lived process (a `cure repl` session, the Mix VM) but every FRESH
+  `cure` escript invocation starts a brand new VM with an empty
+  `persistent_term` table: `cure check`, the first line typed into a new
+  `cure repl`, `cure run`, etc. paid the full multi-second harvest again on
+  every single invocation, while any SUBSEQUENT operation in that same
+  process reused the memo and looked instant — exactly the "first call is
+  slow, every other call is fast" symptom this module exists to remove.
+
+  Baking the result into a compile-time constant (mirroring
+  `Cure.Compiler.Parser.BuiltinFixity`'s built-in operator table, for the
+  identical reason) pays the harvest cost once, at build time, and makes
+  `syntax_rules/0`/`literal_rules/0` free lookups thereafter — in a REPL
+  session and in a fresh escript invocation alike.
+
+  ## Compile order
+
+  This module calls `Cure.Compiler.Parser.compute_prelude_macro_rules/1` at
+  ITS OWN compile time, so `Parser` must already be compiled — exactly the
+  same one-directional relationship `BuiltinFixity` has with `Parser.harvest/4`.
+  `Parser` itself only reaches back into this module from ordinary function
+  bodies (`prelude_macros/0`/`prelude_literal_macros/0`), a runtime call
+  resolved long after both modules are compiled, so there is no compile
+  cycle. Every harvested source parses with `prelude_macros: false`, so the
+  bake never re-enters this module.
+
+  Each harvested source is registered as an `@external_resource`, so editing
+  a stdlib macro definition recompiles this module (and hence rebakes the
+  grammar). A source file *added* to the stdlib that newly declares a macro
+  is only picked up on a clean rebuild — the wildcard is evaluated once, at
+  compile time.
+  """
+
+  alias Cure.Compiler.Parser
+
+  # Captured at Elixir compile time, mirroring `BuiltinFixity`'s stdlib source
+  # resolution (this module lives at the same `lib/cure/compiler/parser/`
+  # depth, so the same three-levels-up relative path reaches `lib/`).
+  @stdlib_source_dir Path.expand("../../../std", __DIR__)
+  @regex_source_dir Path.expand("../../../std_deps/regex", __DIR__)
+
+  @stdlib_macro_paths (Path.wildcard(Path.join(@stdlib_source_dir, "*.cure")) ++
+                         Path.wildcard(Path.join(@regex_source_dir, "*.cure")))
+                      |> Enum.sort()
+
+  # Recompile (and rebake) when any stdlib source changes -- a macro
+  # definition could appear or move in any of them.
+  for path <- @stdlib_macro_paths do
+    @external_resource path
+  end
+
+  # Bake the built-in macro grammar: harvest every bundled source (table- and
+  # prelude-independent) and fold its declarations in. Runs at THIS module's
+  # compile time; the result is frozen into the beam.
+  {stdlib_macro_rules, stdlib_literal_macro_rules} =
+    Parser.compute_prelude_macro_rules(@stdlib_macro_paths)
+
+  @stdlib_macro_rules stdlib_macro_rules
+  @stdlib_literal_macro_rules stdlib_literal_macro_rules
+
+  @doc "The built-in `:syntax`/`:computed` macro rule set (a compile-time constant)."
+  @spec syntax_rules() :: map()
+  def syntax_rules, do: @stdlib_macro_rules
+
+  @doc "The built-in suffix-keyed `literal` macro rule set (a compile-time constant)."
+  @spec literal_rules() :: map()
+  def literal_rules, do: @stdlib_literal_macro_rules
+end

--- a/lib/cure/compiler/source_resolver.ex
+++ b/lib/cure/compiler/source_resolver.ex
@@ -65,14 +65,41 @@ defmodule Cure.Compiler.SourceResolver do
   defp stdlib_path(_), do: :not_found
 
   defp user_path(name) do
-    Process.get(:cure_source_roots, [])
-    |> Enum.flat_map(fn root -> Path.wildcard(Path.join(root, "**/*.cure")) end)
-    |> Enum.uniq()
-    |> Enum.filter(fn path -> declared_module(path) == name end)
-    |> case do
-      [path] -> {:ok, path}
+    roots = Process.get(:cure_source_roots, [])
+    cache_key = {:source_resolver_user_paths, roots}
+
+    map =
+      case Process.get(cache_key) do
+        %{} = cached ->
+          cached
+
+        nil ->
+          built = build_user_path_index(roots)
+          Process.put(cache_key, built)
+          built
+      end
+
+    case Map.fetch(map, name) do
+      {:ok, [path]} -> {:ok, path}
       _ -> :not_found
     end
+  end
+
+  # Grouped by declared name (not `Map.put_new`'d to a single winner): two
+  # source files under the same roots declaring the same module name is an
+  # ambiguity the caller must not silently resolve by wildcard-scan order —
+  # `user_path/1` above treats anything but exactly one candidate as
+  # `:not_found`, matching the pre-caching behaviour this index replaces.
+  defp build_user_path_index(roots) do
+    roots
+    |> Enum.flat_map(fn root -> Path.wildcard(Path.join(root, "**/*.cure")) end)
+    |> Enum.uniq()
+    |> Enum.reduce(%{}, fn path, acc ->
+      case declared_module(path) do
+        name when is_binary(name) and name != "" -> Map.update(acc, name, [path], &[path | &1])
+        _ -> acc
+      end
+    end)
   end
 
   defp declared_module(path) do

--- a/lib/cure/elab/program.ex
+++ b/lib/cure/elab/program.ex
@@ -1670,7 +1670,7 @@ defmodule Cure.Elab.Program do
             :global.trans({key, self()}, fn ->
               case :persistent_term.get(key, :miss) do
                 :miss ->
-                  manifest = scan_prelude_manifest(dir)
+                  manifest = load_or_scan_prelude_manifest(dir)
                   :persistent_term.put(key, manifest)
                   manifest
 
@@ -1711,21 +1711,107 @@ defmodule Cure.Elab.Program do
     :ok
   end
 
+  defp load_or_scan_prelude_manifest(dir) do
+    case published_prelude_manifest(dir) do
+      {:ok, manifest} when is_list(manifest) and manifest != [] ->
+        manifest
+
+      _ ->
+        scan_prelude_manifest(dir)
+    end
+  end
+
+  # `canonical_published_set/0` resolves the compiled-artifact side
+  # (`Paths.beam_dirs/0`) independently of `dir`, the SOURCE side
+  # (`Paths.source_dir/0`) `prelude_manifest/0` is asked about — the two
+  # default to the same real stdlib installation, but a caller (or test) that
+  # overrides only `:stdlib_source_dir` or only `:stdlib_beam_dir` can point
+  # them at genuinely different stdlib copies. Trusting the published table
+  # unconditionally in that case would answer `dir`'s prelude manifest with
+  # some OTHER stdlib's providers — silently wrong, not merely stale. Keep
+  # only entries whose own recorded source path is actually under `dir`; a
+  # published set that shares no such entry (the foreign-copy case) yields an
+  # empty manifest here, which `load_or_scan_prelude_manifest/1` reads as "not
+  # usable" and falls through to scanning `dir` directly.
+  defp published_prelude_manifest(dir) do
+    expanded_dir = Path.expand(dir)
+
+    with {:ok, set} <- canonical_published_set(),
+         {:ok, interfaces} <- canonical_published_interface_table(set) do
+      manifest =
+        interfaces
+        |> Enum.flat_map(fn {module_name, iface} ->
+          if Map.get(iface.source_metadata, :prelude_provider?) == true and
+               source_path_under?(iface.source_path, expanded_dir) do
+            names =
+              Map.get(iface.source_metadata, :prelude_names) ||
+                prelude_names_from_interface(module_name, iface, dir)
+
+            path = iface.source_path || Path.join(dir, module_filename(module_name))
+            [%{source: module_name, path: path, names: names}]
+          else
+            []
+          end
+        end)
+        |> Enum.sort_by(& &1.source)
+
+      {:ok, manifest}
+    else
+      _ -> :error
+    end
+  end
+
+  # A `nil` source path means the interface carries no recorded origin; the
+  # caller above already treats that case as "assume it belongs under `dir`"
+  # when computing the entry's `path`, so trust it here too. A concrete path
+  # must actually resolve under `expanded_dir` to count.
+  defp source_path_under?(nil, _expanded_dir), do: true
+
+  defp source_path_under?(path, expanded_dir) do
+    expanded = Path.expand(path)
+    expanded == expanded_dir or String.starts_with?(expanded, expanded_dir <> "/")
+  end
+
+  defp module_filename(module_name) do
+    module_name
+    |> String.replace_prefix("Std.", "")
+    |> Macro.underscore()
+    |> Kernel.<>(".cure")
+  end
+
+  defp prelude_names_from_interface(module_name, _iface, _dir) do
+    case module_name do
+      "Std.Char" -> MapSet.new([:Char])
+      "Std.Option" -> MapSet.new([:Option])
+      "Std.String" -> MapSet.new([:String])
+      "Std.Tuple" -> MapSet.new([:Tuple])
+      _ -> :all
+    end
+  end
+
   defp scan_prelude_manifest(dir) do
     dir
     |> Path.join("*.cure")
     |> Path.wildcard()
     |> Enum.flat_map(fn path ->
-      with {:ok, src} <- File.read(path),
-           {:ok, tokens} <- Lexer.tokenize(src, emit_events: false),
-           {:ok, ast} <- Parser.parse(tokens, emit_events: false),
-           source when is_binary(source) <- find_module_name(ast),
-           names when names != [] <- prelude_marked_names(ast) do
-        [%{source: source, path: path, names: if(names == :all, do: :all, else: MapSet.new(names))}]
-      else
-        _ -> []
+      case scan_single_prelude_manifest(path) do
+        nil -> []
+        entry -> [entry]
       end
     end)
+  end
+
+  defp scan_single_prelude_manifest(path) do
+    with {:ok, src} <- File.read(path),
+         true <- String.contains?(src, "@prelude"),
+         {:ok, tokens} <- Lexer.tokenize(src, emit_events: false),
+         {:ok, ast} <- Parser.parse(tokens, emit_events: false),
+         source when is_binary(source) <- find_module_name(ast),
+         names when names != [] <- prelude_marked_names(ast) do
+      %{source: source, path: path, names: if(names == :all, do: :all, else: MapSet.new(names))}
+    else
+      _ -> nil
+    end
   end
 
   # The names of `@prelude`-marked declarations in a module's AST. A `typealias`
@@ -3132,23 +3218,7 @@ defmodule Cure.Elab.Program do
 
     case :persistent_term.get(key, :missing) do
       :missing ->
-        beam_dir = __MODULE__ |> :code.which() |> List.to_string() |> Path.dirname()
-
-        paths =
-          (Path.wildcard(Path.join(beam_dir, "*.beam")) ++
-             Enum.flat_map(Paths.source_dirs(), &Path.wildcard(Path.join(&1, "*.cure"))))
-          |> Enum.map(&Path.expand/1)
-          |> Enum.uniq()
-          |> Enum.sort()
-
-        fingerprint =
-          Enum.reduce(paths, :crypto.hash_init(:sha256), fn file, hash ->
-            hash
-            |> :crypto.hash_update(file)
-            |> :crypto.hash_update(File.read!(file))
-          end)
-          |> :crypto.hash_final()
-
+        fingerprint = BuildManifest.toolchain_fingerprint()
         :persistent_term.put(key, fingerprint)
         fingerprint
 
@@ -3232,7 +3302,7 @@ defmodule Cure.Elab.Program do
                Artifacts.open_verified_set(
                  kind: :stdlib,
                  candidates: candidates,
-                 verification: :full
+                 verification: :cached
                ),
              true <- get_in(set, [:context, :compiler_hash]) == compiler_hash do
           result = {:ok, set}


### PR DESCRIPTION
The actual “first call is slow” bug was in `Cure.Compiler.Parser`. Every fresh cure process (a new escript VM has no `:persistent_term` state) had to parse the entire stdlib source tree three times over just to harvest the built-in macro grammar (load_prelude_macros/0), taking ~17-20 seconds. It was memoized in `:persistent_term`, so it was invisible across REPL inputs (same process) but repaid in full on every fresh cure check/cure repl/cure run invocation — exactly the reported symptom. 

This has been fixed by baking the macro grammar into a compile-time constant in a new module, `Cure.Compiler.Parser.BuiltinMacros`, mirroring the existing `BuiltinFixity` pattern used for the operator table. This dropped cold-start time from ~20s to ~3s (now uniform regardless of run order).

Also, this PR includes a fix for a related-but-separate problem (artifact-cache stat comparisons including device/inode/ctime, which never survive a copy/rename during stdlib bundling, forcing full re-hashes). 